### PR TITLE
Fixed codepen link

### DIFF
--- a/data/sponsors.yml
+++ b/data/sponsors.yml
@@ -133,7 +133,7 @@
   links:
     twitter: ~
     facebook: ~
-    website: http://codepen.com/
+    website: http://codepen.io/
 - sponsor:
   type: tertiary
   name: The Daemon Fund


### PR DESCRIPTION
seems that it should be codepen.io, not codepen.com
