### PR TITLE
Set pointer events to none so links remain clickable behind gradient

### DIFF
--- a/source/assets/stylesheets/responsive/_large.css.scss
+++ b/source/assets/stylesheets/responsive/_large.css.scss
@@ -29,6 +29,7 @@ html, body {
       position: fixed;
       width: 722px;
       z-index: 10;
+      pointer-events: none;
     }
     &:before {
       @include background-image( linear-gradient($yellow 20%, rgba($yellow, 0)));


### PR DESCRIPTION
If you click on the `Code of conduct` link and scroll down, the `Geek Feminism wiki` link is not clickable. Added `pointer-events: none;` to fix this.